### PR TITLE
Fixed Fav View

### DIFF
--- a/RSSRead/SMRSSListViewController.m
+++ b/RSSRead/SMRSSListViewController.m
@@ -252,6 +252,7 @@
     SMDetailViewController *detailVC = [SMDetailViewController new];
     detailVC.delegate = self;
     [detailVC setRss:rss];
+    detailVC.hidesBottomBarWhenPushed = YES;
     [self.navigationController pushViewController:detailVC animated:YES];
     
     SMRSSModel *rssModel = [SMRSSModel new];


### PR DESCRIPTION
Fixed issue when entering the detail view at favVC. The bottom bar is covered by tab bar.
修复收藏页面中底面条被tabbar遮住导致文章无法返回。
