### PR TITLE
解决RSS列表详情页发表时间显示为null的问题

### DIFF
--- a/RSSRead/SMDetailViewController.m
+++ b/RSSRead/SMDetailViewController.m
@@ -144,6 +144,9 @@
     formatter = [[NSDateFormatter alloc] init];
     [formatter setDateFormat:@"MM.dd HH:mm"];
     NSString *publishDate = [formatter stringFromDate:_rss.date];
+    if (!publishDate) {
+        publishDate = @"未知时间";
+    }
     NSString *htmlStr = [NSString stringWithFormat:@"<!DOCTYPE html><html lang=\"zh-CN\"><head><meta charset=\"utf-8\"><meta http-equiv=\"X-UA-Compatible\" content=\"IE=edge\"><meta name=\"viewport\" content=\"width=device-width initial-scale=1.0\">%@</head><body><a class=\"title\" href=\"%@\">%@</a>\
                          <div class=\"diver\"></div><p style=\"text-align:left;font-size:9pt;margin-left: 14px;margin-top: 10px;margin-bottom: 10px;color:#CCCCCC\">%@ 发表于 %@</p><div class=\"content\">%@</div>%@</body></html>", cssString, _rss.link, _rss.title, _rss.author, publishDate, _showContent, mTxt];
     [_webView loadHTMLString:htmlStr baseURL:nil];

--- a/RSSRead/SMRSSListCell.m
+++ b/RSSRead/SMRSSListCell.m
@@ -54,7 +54,9 @@ const NSInteger kRSSListCellDateMarginTop = 6;
 -(void)setRss:(RSS *)rss {
     [_lbTitle setText:rss.title];
 //    [_lbSource setText:_subscribeTitle];
-    [_lbDate setText:[NSString stringWithFormat:@"[%@]",[_formatter stringFromDate:rss.date]]];
+    if (rss.date) {
+        [_lbDate setText:[NSString stringWithFormat:@"[%@]",[_formatter stringFromDate:rss.date]]];
+    }
     if ([rss.isFav isEqual:@1]) {
         _lbTitle.textColor = [SMUIKitHelper colorWithHexString:LIST_YELLOW_COLOR];
     } else if([rss.isRead  isEqual: @1]) {
@@ -91,6 +93,8 @@ const NSInteger kRSSListCellDateMarginTop = 6;
         rect.size = fitSize;
         //        rect.origin.x = SCREEN_WIDTH - fitSize.width - 11;
         _lbDate.frame = rect;
+    } else {
+        fitSize.width = -2;
     }
     
     //简介


### PR DESCRIPTION
解决方案是将发表时间隐藏，发表时间显示为null的根本原因是某些RSS源发布时间格式不规范